### PR TITLE
Made tree rotation od Domov start at 0 and end at 360

### DIFF
--- a/drevo.js
+++ b/drevo.js
@@ -23,11 +23,11 @@ function draw2(lenght){
     if(lenght>10)
     {
         push();
-        rotate((mouseX/10)/(TWO_PI*8));
+        rotate((mouseX/windowWidth*TWO_PI)-TWO_PI/2.93);
         draw2(lenght * 0.66);
         pop();
         push();
-        rotate(-(mouseX/10*0.3)/(TWO_PI*8));
+        rotate(-((mouseX/windowWidth*TWO_PI)-TWO_PI/2.93)*0.3);
         draw2(lenght * 0.66);
         pop();
     }


### PR DESCRIPTION
Made the rotation the Domov screen start at zero by dividing the mouseX with the window screen, giving us a range from 0 to 1, then multiplying that by 2 pi aka. a full circle. This made an offset so manually subtracted two_pi/2.93 which was discovered by brute force. Made the other branch do the same in a different direction but made it move 0.3x as fast.